### PR TITLE
Source image changed in order to reduce size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,12 @@
 # docker inspect --format "{{ .NetworkSettings.IPAddress }}" iperf3-srv
 # docker run  -it --rm networkstatic/iperf3 -c <SERVER_IP>
 #
-FROM debian:latest
+FROM debian:buster-slim
 MAINTAINER Brent Salisbury <brent.salisbury@gmail.com>
 # install binary and remove cache
 RUN apt-get update \
     && apt-get install -y iperf3 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Expose the default iperf3 server port
@@ -21,3 +22,4 @@ EXPOSE 5201
 # very similar to a binary you would run. For example, in the following
 # docker run -it <IMAGE> --help' is like running 'iperf3 --help'
 ENTRYPOINT ["iperf3"]
+


### PR DESCRIPTION
Image change to debian:buster-slim, image size reduced from 120 MB to 75 MB.

```
iperf-slim                    latest        ef2cebe7c28c   7 minutes ago   75.1MB
iperf                         latest        057cfd35dc9a   9 minutes ago   120MB
```